### PR TITLE
Workaround for DAFFODIL-2974

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,6 @@ name := "dfdl-tcpMessage"
 
 organization := "io.github.dfdlschemas"
 
-version := "1.0.0"
+version := "1.1.0"
 
 enablePlugins(DaffodilPlugin)

--- a/src/main/resources/io/github/dfdlschemas/tcpMessage/xsd/tcpMessageType.dfdl.xsd
+++ b/src/main/resources/io/github/dfdlschemas/tcpMessage/xsd/tcpMessageType.dfdl.xsd
@@ -19,8 +19,6 @@
     </appinfo>
   </annotation>
 
-  <element name="message" type="tcpHdr:messageType"/>
-
   <complexType name="messageType">
     <sequence>
       <sequence dfdl:hiddenGroupRef="tcpHdr:lengthGroup"/>

--- a/src/test/resources/io/github/dfdlschemas/tcpMessage/test_01.dat.xml
+++ b/src/test/resources/io/github/dfdlschemas/tcpMessage/test_01.dat.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<tcpHdr:message   xmlns:tcpHdr="urn:io.github.dfdlschemas.tcpMessage">
+<message>
   <data><content>DEADBEEF</content></data>
-</tcpHdr:message>
+</message>

--- a/src/test/resources/io/github/dfdlschemas/tcpMessage/xsd/tcpMessage.dfdl.xsd
+++ b/src/test/resources/io/github/dfdlschemas/tcpMessage/xsd/tcpMessage.dfdl.xsd
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:tcpHdr="urn:io.github.dfdlschemas.tcpMessage"
+  elementFormDefault="unqualified">
+
+  <xs:import
+    namespace="urn:io.github.dfdlschemas.tcpMessage"
+    schemaLocation="/io/github/dfdlschemas/tcpMessage/xsd/tcpMessageType.dfdl.xsd"/>
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:format ref="tcpHdr:baseFormat"/>
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:element name="message" type="tcpHdr:messageType"/>
+
+</xs:schema>


### PR DESCRIPTION
This schema no longer defines a root element for use by other schemas.

Rather, it defines the root element, just for testing, in no namespace under src/test only.

To use this schema, you use the complexType messageType in an element with name of your own choosing.

This was required due to bug DAFFODIL-2947